### PR TITLE
fix: use slash key '/' to open chat

### DIFF
--- a/src/pyrobloxbot/__init__.py
+++ b/src/pyrobloxbot/__init__.py
@@ -298,10 +298,7 @@ def chat(message:str):
     :type message: str
     """
     #Open chat
-    dinput.keyDown("shift")
-    dinput.keyDown("7")
-    dinput.keyUp("shift")
-    dinput.keyUp("7")
+    dinput.press("/")
 
     #Use clipboard to paste message quickly
     previousClipboard = pyclip.paste()


### PR DESCRIPTION
the old code used shift+7 (in most keyboards outputs "&") for opening the chat.

the new code uses "/" instead.