### PR TITLE
Add CI to build and publish to pypi on release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,14 @@
+name: Publish to PyPi
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    uses: Mews/.github/.github/workflows/publish-python-package.yaml@main
+    with:
+      python_version: '3.10'
+      os: 'windows-latest'
+    permissions:
+      id-token: write


### PR DESCRIPTION
<!-- !! Thank you for opening a PR !! ❤️❤️ -->

<!--- Provide a short summary of your changes in the Title above -->

## Description
Use my `Mews/.github/.github/workflows/publish-python-package.yaml@main` workflow to build and publish the wheels when a release is published on github

## Related Issue
<!--- If applicable, please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
<!--- You can delete the checkboxes that don't apply -->
- [x] Closes #10 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
<!--- If not applicable, check the box -->
- [x] The pre-commit checks all pass (see [contributing.md](../CONTRIBUTING.md))
- [x] Added necessary documentation (if applicable)
- [x] Added tests to cover new features (if applicable)
