### PR TITLE
Use pydirectinput in `require_focus`

### DIFF
--- a/src/pyrobloxbot/core/decorators.py
+++ b/src/pyrobloxbot/core/decorators.py
@@ -2,7 +2,7 @@ from functools import wraps
 from pygetwindow import getActiveWindow, getWindowsWithTitle
 from win32gui import GetForegroundWindow, GetWindowText
 
-import pyautogui
+import pydirectinput
 from ..exceptions import NoRobloxWindowException
 from ..bot.bot import state
 
@@ -35,7 +35,7 @@ def require_focus(fn):
 
             # Set focus to roblox window
             else:
-                pyautogui.press("altleft")
+                pydirectinput.press("altleft")
                 rblxWindow.maximize()
                 rblxWindow.activate()
 

--- a/tests/test_core/test_decorators.py
+++ b/tests/test_core/test_decorators.py
@@ -27,12 +27,12 @@ def test_require_focus_no_roblox_window(_, __, ___):
 
 
 @patch("pyrobloxbot.core.decorators.getActiveWindow", return_value="Not None")
-@patch("pyrobloxbot.core.decorators.pyautogui")
+@patch("pyrobloxbot.core.decorators.pydirectinput")
 @patch("pyrobloxbot.core.decorators.getWindowsWithTitle")
 @patch("pyrobloxbot.core.decorators.GetWindowText", return_value="Not Roblox")
 @patch("pyrobloxbot.core.decorators.GetForegroundWindow")
 def test_require_focus_window_not_already_active(
-    _, __, mock_getWindowsWithTitle, mock_pyautogui, ___
+    _, __, mock_getWindowsWithTitle, mock_pydirectinput, ___
 ):
     mock_window = MagicMock()
     mock_window.title = "Roblox"
@@ -45,7 +45,7 @@ def test_require_focus_window_not_already_active(
 
     assert dummy_function() == "success"
 
-    mock_pyautogui.press.assert_called_once_with("altleft")
+    mock_pydirectinput.press.assert_called_once_with("altleft")
     mock_window.maximize.assert_called_once()
     mock_window.activate.assert_called_once()
 


### PR DESCRIPTION
<!-- !! Thank you for opening a PR !! ❤️❤️ -->

<!--- Provide a short summary of your changes in the Title above -->

## Description
Instead of using pyautogui to press altleft, to fix the "pygetwindow.PyGetWindowException: Error code from Windows: 0 - The operation completed successfully." issue (fixed in 02db8570959003aa684294bddd88d689e25eba7e) we use pydirectinput, which we use for the kest of basic key presses

## Related Issue
<!--- If applicable, please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
<!--- You can delete the checkboxes that don't apply -->
- [x] Related to #57 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
<!--- If not applicable, check the box -->
- [x] The pre-commit checks all pass (see [contributing.md](../CONTRIBUTING.md))
- [x] Added necessary documentation (if applicable)
- [x] Added tests to cover new features (if applicable)
