### PR TITLE
Fix jump delay bug

### DIFF
--- a/src/pyrobloxbot/core/movement.py
+++ b/src/pyrobloxbot/core/movement.py
@@ -108,9 +108,11 @@ def jump(number_of_jumps: int = 1, interval: float = 0) -> None:
     :param interval: How much time between jumps, in seconds, defaults to 0
     :type interval: float
     """
-    for _ in range(number_of_jumps):
+    for i in range(number_of_jumps):
         press_key(keybinds.jump)
-        wait(interval)
+
+        if i != number_of_jumps - 1:
+            wait(interval)
 
 
 @apply_cooldown

--- a/tests/test_core/test_movement.py
+++ b/tests/test_core/test_movement.py
@@ -1,5 +1,5 @@
 import pytest
-from unittest.mock import patch, call
+from unittest.mock import patch, call, Mock
 
 import pyrobloxbot as bot
 
@@ -169,7 +169,29 @@ def test_jump(mock_press_key, mock_wait):
     bot.jump(10, 5)
 
     mock_press_key.assert_has_calls([call("space")] * 10)
-    mock_wait.assert_has_calls([call(5)] * 10)
+    mock_wait.assert_has_calls([call(5)] * 9)
+
+
+def test_jump_issue_41(mock_press_key, mock_wait):
+    manager = Mock()
+    manager.attach_mock(mock_press_key, "mock_press_key")
+    manager.attach_mock(mock_wait, "mock_wait")
+
+    bot.jump(5, 2)
+
+    expected_calls = [
+        call.mock_press_key(bot.keybinds.jump),
+        call.mock_wait(2),
+        call.mock_press_key(bot.keybinds.jump),
+        call.mock_wait(2),
+        call.mock_press_key(bot.keybinds.jump),
+        call.mock_wait(2),
+        call.mock_press_key(bot.keybinds.jump),
+        call.mock_wait(2),
+        call.mock_press_key(bot.keybinds.jump),
+    ]
+
+    assert manager.mock_calls == expected_calls
 
 
 def test_jump_continous(mock_hold_key):


### PR DESCRIPTION
<!-- !! Thank you for opening a PR !! ❤️❤️ -->

<!--- Provide a short summary of your changes in the Title above -->

## Description
Changed the `jump` method to not call wait after the last key press

## Related Issue
<!--- If applicable, please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
<!--- You can delete the checkboxes that don't apply -->
- [x] Closes #41 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
<!--- If not applicable, check the box -->
- [x] The pre-commit checks all pass (see [contributing.md](../CONTRIBUTING.md))
- [x] Added necessary documentation (if applicable)
- [x] Added tests to cover new features (if applicable)
