### PR TITLE
Mock mouse and win32con for autodoc

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -34,7 +34,9 @@ autodoc_mock_imports = [
     "pillow",
     "pyscreeze",
     "win32gui",
+    "win32con",
     "PIL",
+    "mouse",
 ]
 
 myst_enable_extensions = [


### PR DESCRIPTION
<!-- !! Thank you for opening a PR !! ❤️❤️ -->

<!--- Provide a short summary of your changes in the Title above -->

## Description
Mocked the `mouse` and `win32con` imports so autodoc can import pyrobloxbot to make the api references.

## Related Issue
<!--- If applicable, please type an `x` in one of the boxes below and provide the issue number after the # sign: -->
<!--- You can delete the checkboxes that don't apply -->
- [x] Closes #133 

## Checklist
<!--- Make sure you have completed the following steps before submitting your PR -->
<!--- Feel free to type an `x` in all the boxes below to let us know you have completed the steps: -->
<!--- If not applicable, check the box -->
- [x] The pre-commit checks all pass (see [contributing.md](../CONTRIBUTING.md))
- [x] Added necessary documentation (if applicable)
- [x] Added tests to cover new features (if applicable)
